### PR TITLE
Sửa lỗi mode SPI khi sử dụng hardware SPI

### DIFF
--- a/PS2X_lib.cpp
+++ b/PS2X_lib.cpp
@@ -253,7 +253,7 @@ byte PS2X::config_gamepad(SPIClass* spi, uint8_t att, bool pressures, bool rumbl
   pinMode(att, OUTPUT); ATT_SET();
 
 #if defined(SPI_HAS_TRANSACTION)
-  _spi_settings = SPISettings(CTRL_BITRATE, LSBFIRST, SPI_MODE2);
+  _spi_settings = SPISettings(CTRL_BITRATE, LSBFIRST, SPI_MODE0);
 #endif
 
   if(begin) _spi->begin(); // begin SPI with default settings

--- a/PS2X_lib.cpp
+++ b/PS2X_lib.cpp
@@ -636,7 +636,10 @@ byte PS2X::config_gamepad_arduino_spi(uint8_t att, bool pressures, bool rumble) 
   return config_gamepad(&SPI, att, pressures, rumble);
 }
 
-#if defined(ESP32)
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
+#define VSPI FSPI
+#endif
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
 byte PS2X::config_gamepad_esp32_hspi(uint8_t att) {
   return config_gamepad_esp32_hspi(att, false, false);
 }

--- a/PS2X_lib.h
+++ b/PS2X_lib.h
@@ -226,7 +226,7 @@ class PS2X {
     // ready-to-use config functions for select boards (right now only supports Arduino with default SPI port and ESP32 HSPI and VSPI)
     byte config_gamepad_arduino_spi(uint8_t); // specify ATT pin. please note that using this on ESP32 is functionally similar to config_gamepad_esp32_vspi(uint8_t)
     byte config_gamepad_arduino_spi(uint8_t, bool, bool); // specify ATT pin and pressure&rumble mode. please note that using this on ESP32 is functionally similar to config_gamepad_esp32_vspi(uint8_t, bool, bool)
-#if defined(ESP32)
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
     // HSPI
     byte config_gamepad_esp32_hspi(uint8_t); // use HSPI with custom ATT pin
     byte config_gamepad_esp32_hspi(uint8_t, bool, bool); // use HSPI with custom ATT pin, also specify whether to enable pressure and rumble
@@ -290,7 +290,7 @@ class PS2X {
       port_reg_t *_att_lport_clr;
       port_mask_t _dat_mask; 
       port_reg_t *_dat_lport;
-    #else // platform does not have port registers (eg. ESP8266, ESP32)
+#else // platform does not have port registers (eg. ESP8266, ESP32, ESP32C3, ESP32S3)
 
       int _clk_pin;
       int _cmd_pin;


### PR DESCRIPTION
Trước đây, khi sử dụng hardware SPI để giao tiếp với tay cầm PS2, Arduino được thiết lập ở mode 2. Một số mạch (VD như ESP32) có cách tạo xung SCK sao cho tín hiệu trên chân MOSI chỉ thay đổi khi chân SCK từ 1 về 0, nhưng ở một số mạch khác (VD như Arduino Uno), chân MOSI bị thay đổi ngay khi chân SCK từ 0 lên 1, làm cho tay cầm PS2 không kịp capture bit vừa rồi và dẫn tới lỗi giao tiếp. Commit này đổi mode về 0 để khắc phục điều này.